### PR TITLE
Build a table of types of failures for all events

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ docker>=5.0.3
 docker-compose>=1.29.2
 websocket-client<1,>=0.32.0
 pytest-docker-compose>=1.0.1
+prettytable>=3.2.0

--- a/src/tests/integration/test_integration.py
+++ b/src/tests/integration/test_integration.py
@@ -7,7 +7,7 @@ from typing import Callable
 from docker import DockerClient
 from itertools import permutations
 from src.tools.enums import ServiceType
-from src.tools.utils import file_cmp
+from src.tools.utils import event_check
 
 
 _logger = logging.getLogger(__name__)
@@ -215,4 +215,4 @@ class TestApp:
 
         partials = [file.extractfile(rx_events.name) for file in files]
         _logger.info(f'Determine if aggregate events in {rx_events.name} match {tx_events.name}')
-        file_cmp(tx_events, *partials)
+        event_check(tx_events, *partials)


### PR DESCRIPTION
Attempt to solve the issues by reading the Master list of events into a hash, doing a lookup for each line of the target files, and keeping a running tally of each event. After the lookup, should have a hash that contains how many times each event was seen. Then just transfer that to some output for debug:

```
E   AssertionError: Event errors found:
E   +--------+-----------+---------+---------+
E   | valid  | duplicate | missing | invalid |
E   +--------+-----------+---------+---------+
E   | 999992 |     0     |    8    |    8    |
E   +--------+-----------+---------+---------+
```

Tested at 1m entries and 20m. 

Two issues with this approach:
1. The larger the event set, the more time this will take. (20m @23s)
2. If the master event set has duplicates, we won't see that in the hash. We would to add a differentiator somehow.